### PR TITLE
feat: exit program with status code 1 on error

### DIFF
--- a/cli/cmd/aasa_validate.go
+++ b/cli/cmd/aasa_validate.go
@@ -26,7 +26,7 @@ var validateAASACmd = &cobra.Command{
 				fmt.Print(item)
 			}
 
-			return
+			cobra.CheckErr(err)
 		} else {
 			output := yurllib.CheckAASADomain(args[0], "", "", true)
 

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yurllib/aasa.go
+++ b/yurllib/aasa.go
@@ -148,12 +148,13 @@ func CheckAASAFile(filePath string) (output []string, err error) {
 	bundleIdentifier := ""
 	teamIdentifier := ""
 
-	output, errors := evaluateAASA(fileContent, contentType, bundleIdentifier, teamIdentifier)
-	if len(errors) > 0 {
+	output, errs := evaluateAASA(fileContent, contentType, bundleIdentifier, teamIdentifier)
+	if len(errs) > 0 {
 		output = append(output, fmt.Sprintln("\nErrors:"))
-		for _, e := range errors {
+		for _, e := range errs {
 			output = append(output, fmt.Sprintf("  - %s\n", e))
 		}
+		return output, errors.New("AASA validation failed")
 	}
 
 	return output, err


### PR DESCRIPTION
When validating a local AASA file, if there are errors, the program should exit with the correct status code (`1` is the convention) so that we can rely on that to tell whether the validation is successful. Currently, the result is only output to `stdout`, which is useful for humans but not programs (especially in CI/CD).

I tried to write an (integration) test for this but haven't had much success. I'll continue to work on that separately to not block the merge of this change.