### PR TITLE
chore: use golangci-lint for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,3 +40,15 @@ jobs:
         run: |
           go test -v -timeout 30s -race -covermode=atomic -coverprofile=coverage.out ./...
           go tool cover -func coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+'
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+issues:
+  exclude-rules:
+    - path: yurllib/aasa.go
+      text: "SA9003: empty branch"


### PR DESCRIPTION
Use the [GitHub Action](https://github.com/golangci/golangci-lint-action) provided by [`golangci-lint`](https://golangci-lint.run/) to run linting for this project. `golangci-lint` is one of the most popular linters for Go out there with great integration/support for VS Code too.